### PR TITLE
deps(nodejs): require exactly v 16.9.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,16 @@ jobs:
           DATABASE_USERNAME: postgres
           DATABASE_PASSWORD: postgres
 
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
       - name: Precompile assets
         run: |
-          yarn install
+          npm ci
           bundle exec rake assets:precompile
         env:
           RAILS_ENV: test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,9 @@
         "eslint-config-standard": "^11.0.0",
         "eslint-plugin-import": "^2.25.4",
         "stylelint": "^13.11.0"
+      },
+      "engines": {
+        "node": "16.9.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1745,8 +1748,8 @@
         "uuid": "^3.2.1"
       },
       "engines": {
-        "node": "^16.9.1",
-        "npm": "^7.21.1"
+        "node": "16.9.1",
+        "npm": "7.21.1"
       }
     },
     "node_modules/@decidim/decidim-bulletin_board": {

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.25.4",
     "stylelint": "^13.11.0"
+  },
+  "engines": {
+    "node": "16.9.1"
   }
 }


### PR DESCRIPTION
## Description

This pr tries to fix the deployment issue with `nodejs`:

- updated `.github/workflows/test.yml` to use the node version
- added `.npmrc` file to prevent npm to install  not supported Node.js versions [more info](https://www.stefanjudis.com/today-i-learned/prevent-npm-install-for-not-supported-node-js-versions/)
- added `engines` entry to `package.json` with node version.

This is the error raised when deploying with capistrano:

```
The deploy has failed with an error: Exception while executing as decidim@168.119.180.57: cd /home/decidim/decidim-coincidim/releases/20220321094132; npm ci exit status: 137
cd /home/decidim/decidim-coincidim/releases/20220321094132; npm ci stdout: Nothing written
cd /home/decidim/decidim-coincidim/releases/20220321094132; npm ci stderr: npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@decidim/core@0.26.0',
npm WARN EBADENGINE   required: { node: '^16.9.1', npm: '^7.21.1' },
npm WARN EBADENGINE   current: { node: 'v16.14.0', npm: '8.3.1' }
npm WARN EBADENGINE }
```